### PR TITLE
fix: replace deprecated gopkg.in/yaml.v3 with goccy/go-yaml

### DIFF
--- a/cmd/behavioral-report/main.go
+++ b/cmd/behavioral-report/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/complytime/complyctl/tests/behavioral"
 	"github.com/gemaraproj/go-gemara"
 	"github.com/gemaraproj/go-gemara/gemaraconv"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/yaml.v3 v3.0.1
 	oras.land/oras-go/v2 v2.6.0
 )
 
@@ -62,4 +61,5 @@ require (
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Summary

- Replace direct usage of `gopkg.in/yaml.v3` in `cmd/behavioral-report/main.go` with `github.com/goccy/go-yaml`, which is already a direct dependency used across the rest of the codebase
- `gopkg.in/yaml.v3` remains as an `// indirect` dependency only, pulled in by third-party packages (`testify`, `go-oscal`)
- Add `behavioral-report` binary to `.gitignore`

## Test plan

- [ ] `go build ./cmd/behavioral-report/...` succeeds
- [ ] `go mod tidy` produces no changes

Made with [Cursor](https://cursor.com)