### PR TITLE
docs: update policy URLs to per-bundle repo format with policies- prefix

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -614,26 +614,52 @@
       "package": "cli",
       "function": "runScanAndReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 356,
+      "line": 359,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
     },
     {
       "package": "cli",
+      "function": "processScanOutput",
+      "file": "cmd/complyctl/cli/scan.go",
+      "line": 373,
+      "complexity": 2,
+      "line_coverage": 83.33333333333333,
+      "crap": 2.0185185185185186
+    },
+    {
+      "package": "cli",
+      "function": "reportOperationalWarnings",
+      "file": "cmd/complyctl/cli/scan.go",
+      "line": 388,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "cli",
+      "function": "checkOperationalErrors",
+      "file": "cmd/complyctl/cli/scan.go",
+      "line": 397,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "cli",
       "function": "buildEvaluator",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 369,
+      "line": 408,
       "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
+      "line_coverage": 100,
+      "crap": 4
     },
     {
       "package": "cli",
       "function": "filterTargetByID",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 386,
+      "line": 425,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -642,7 +668,7 @@
       "package": "cli",
       "function": "filterTargetsForPolicy",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 395,
+      "line": 434,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -651,7 +677,7 @@
       "package": "cli",
       "function": "checkGenerationFreshness",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 405,
+      "line": 444,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -660,7 +686,7 @@
       "package": "cli",
       "function": "needsRegeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 420,
+      "line": 459,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -669,7 +695,7 @@
       "package": "cli",
       "function": "runGeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 433,
+      "line": 472,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -678,7 +704,7 @@
       "package": "cli",
       "function": "generateForAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 449,
+      "line": 488,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -688,7 +714,7 @@
       "package": "cli",
       "function": "executeScan",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 460,
+      "line": 499,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -697,7 +723,7 @@
       "package": "cli",
       "function": "scanAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 468,
+      "line": 507,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -707,7 +733,7 @@
       "package": "cli",
       "function": "scanSingleTarget",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 486,
+      "line": 533,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -716,26 +742,25 @@
       "package": "cli",
       "function": "writeScanReports",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 503,
+      "line": 552,
       "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
+      "line_coverage": 75,
+      "crap": 3.140625
     },
     {
       "package": "cli",
       "function": "writeFormatReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 518,
+      "line": 567,
       "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
+      "line_coverage": 40,
+      "crap": 7.4559999999999995
     },
     {
       "package": "cli",
       "function": "writePrettyReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 530,
+      "line": 579,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -744,7 +769,7 @@
       "package": "cli",
       "function": "writeSARIFReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 541,
+      "line": 590,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -753,7 +778,7 @@
       "package": "cli",
       "function": "writeOSCALReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 550,
+      "line": 599,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -762,7 +787,7 @@
       "package": "cli",
       "function": "(*scanOptions).runExport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 561,
+      "line": 610,
       "complexity": 5,
       "line_coverage": 16.666666666666668,
       "crap": 19.467592592592588,
@@ -772,7 +797,7 @@
       "package": "cli",
       "function": "authRequired",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 587,
+      "line": 636,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -781,7 +806,7 @@
       "package": "cli",
       "function": "validateAuthCredentials",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 591,
+      "line": 640,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -790,7 +815,7 @@
       "package": "cli",
       "function": "resolveCollectorAuth",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 598,
+      "line": 647,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -800,7 +825,7 @@
       "package": "cli",
       "function": "exportToProviders",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 613,
+      "line": 662,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -809,7 +834,7 @@
       "package": "cli",
       "function": "exportSingleProvider",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 621,
+      "line": 670,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -818,7 +843,7 @@
       "package": "cli",
       "function": "resolveOIDCToken",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 638,
+      "line": 687,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -827,7 +852,7 @@
       "package": "cli",
       "function": "formatExportSummary",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 651,
+      "line": 700,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -836,7 +861,7 @@
       "package": "cli",
       "function": "appendExportRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 671,
+      "line": 720,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -845,7 +870,7 @@
       "package": "cli",
       "function": "appendResponseRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 685,
+      "line": 734,
       "complexity": 3,
       "line_coverage": 85.71428571428571,
       "crap": 3.0262390670553936
@@ -854,7 +879,7 @@
       "package": "cli",
       "function": "exportResponseStatus",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 698,
+      "line": 747,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -863,7 +888,7 @@
       "package": "cli",
       "function": "countExportFailures",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 720,
+      "line": 769,
       "complexity": 7,
       "line_coverage": 100,
       "crap": 7
@@ -872,7 +897,7 @@
       "package": "cli",
       "function": "extractReqToControlMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 739,
+      "line": 788,
       "complexity": 6,
       "line_coverage": 90,
       "crap": 6.036
@@ -1036,13 +1061,21 @@
     },
     {
       "package": "main",
+      "function": "(*contentStore).seedPolicyFromFiles",
+      "file": "cmd/mock-oci-registry/main.go",
+      "line": 449,
+      "complexity": 3,
+      "line_coverage": 0,
+      "crap": 12
+    },
+    {
+      "package": "main",
       "function": "(*contentStore).seedDefaults",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 447,
-      "complexity": 5,
+      "line": 466,
+      "complexity": 1,
       "line_coverage": 0,
-      "crap": 30,
-      "fix_strategy": "add_tests"
+      "crap": 2
     },
     {
       "package": "main",
@@ -1088,1149 +1121,6 @@
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
-    },
-    {
-      "package": "config",
-      "function": "NewConfig",
-      "file": "complytime-providers/cmd/ampel-provider/config/config.go",
-      "line": 28,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "config",
-      "function": "ampelDir",
-      "file": "complytime-providers/cmd/ampel-provider/config/config.go",
-      "line": 33,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "config",
-      "function": "EnsureDirectories",
-      "file": "complytime-providers/cmd/ampel-provider/config/config.go",
-      "line": 38,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "config",
-      "function": "GranularPolicyDirPath",
-      "file": "complytime-providers/cmd/ampel-provider/config/config.go",
-      "line": 56,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "config",
-      "function": "ResultsDirPath",
-      "file": "complytime-providers/cmd/ampel-provider/config/config.go",
-      "line": 61,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "config",
-      "function": "GeneratedPolicyDirPath",
-      "file": "complytime-providers/cmd/ampel-provider/config/config.go",
-      "line": 66,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "config",
-      "function": "SpecDirPath",
-      "file": "complytime-providers/cmd/ampel-provider/config/config.go",
-      "line": 71,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "convert",
-      "function": "LoadGranularPolicies",
-      "file": "complytime-providers/cmd/ampel-provider/convert/convert.go",
-      "line": 20,
-      "complexity": 9,
-      "line_coverage": 0,
-      "crap": 90,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "convert",
-      "function": "MatchPolicies",
-      "file": "complytime-providers/cmd/ampel-provider/convert/convert.go",
-      "line": 61,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "convert",
-      "function": "MergeToBundle",
-      "file": "complytime-providers/cmd/ampel-provider/convert/convert.go",
-      "line": 90,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "convert",
-      "function": "WritePolicy",
-      "file": "complytime-providers/cmd/ampel-provider/convert/convert.go",
-      "line": 107,
-      "complexity": 6,
-      "line_coverage": 0,
-      "crap": 42,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "intoto",
-      "function": "UnwrapDSSE",
-      "file": "complytime-providers/cmd/ampel-provider/intoto/intoto.go",
-      "line": 18,
-      "complexity": 6,
-      "line_coverage": 0,
-      "crap": 42,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "main",
-      "function": "main",
-      "file": "complytime-providers/cmd/ampel-provider/main.go",
-      "line": 10,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "results",
-      "function": "ParseAmpelOutput",
-      "file": "complytime-providers/cmd/ampel-provider/results/results.go",
-      "line": 90,
-      "complexity": 16,
-      "line_coverage": 0,
-      "crap": 272,
-      "fix_strategy": "decompose_and_test"
-    },
-    {
-      "package": "results",
-      "function": "WritePerRepoResult",
-      "file": "complytime-providers/cmd/ampel-provider/results/results.go",
-      "line": 171,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "results",
-      "function": "ToScanResponse",
-      "file": "complytime-providers/cmd/ampel-provider/results/results.go",
-      "line": 195,
-      "complexity": 9,
-      "line_coverage": 0,
-      "crap": 90,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "results",
-      "function": "mapResult",
-      "file": "complytime-providers/cmd/ampel-provider/results/results.go",
-      "line": 265,
-      "complexity": 5,
-      "line_coverage": 0,
-      "crap": 30,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "results",
-      "function": "stripControlChars",
-      "file": "complytime-providers/cmd/ampel-provider/results/results.go",
-      "line": 281,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "results",
-      "function": "isPrintableASCII",
-      "file": "complytime-providers/cmd/ampel-provider/results/results.go",
-      "line": 290,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "scan",
-      "function": "(ExecRunner).Run",
-      "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-      "line": 53,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "scan",
-      "function": "(ExecRunner).RunWithEnv",
-      "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-      "line": 59,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "scan",
-      "function": "buildTokenEnv",
-      "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-      "line": 68,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "scan",
-      "function": "WriteSpecFiles",
-      "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-      "line": 89,
-      "complexity": 7,
-      "line_coverage": 0,
-      "crap": 56,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "scan",
-      "function": "ResolveSpecPath",
-      "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-      "line": 132,
-      "complexity": 6,
-      "line_coverage": 0,
-      "crap": 42,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "scan",
-      "function": "sanitizeSpecName",
-      "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-      "line": 151,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "scan",
-      "function": "constructSnappyCommand",
-      "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-      "line": 165,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "scan",
-      "function": "constructAmpelVerifyCommand",
-      "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-      "line": 190,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "scan",
-      "function": "extractSubjectHash",
-      "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-      "line": 215,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "scan",
-      "function": "extractHashFromStatement",
-      "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-      "line": 223,
-      "complexity": 5,
-      "line_coverage": 0,
-      "crap": 30,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "scan",
-      "function": "ScanRepository",
-      "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-      "line": 243,
-      "complexity": 11,
-      "line_coverage": 0,
-      "crap": 132,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "server",
-      "function": "New",
-      "file": "complytime-providers/cmd/ampel-provider/server/server.go",
-      "line": 38,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "server",
-      "function": "(*ProviderServer).Describe",
-      "file": "complytime-providers/cmd/ampel-provider/server/server.go",
-      "line": 43,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "server",
-      "function": "(*ProviderServer).Generate",
-      "file": "complytime-providers/cmd/ampel-provider/server/server.go",
-      "line": 54,
-      "complexity": 10,
-      "line_coverage": 0,
-      "crap": 110,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "server",
-      "function": "(*ProviderServer).Scan",
-      "file": "complytime-providers/cmd/ampel-provider/server/server.go",
-      "line": 118,
-      "complexity": 17,
-      "line_coverage": 0,
-      "crap": 306,
-      "fix_strategy": "decompose_and_test"
-    },
-    {
-      "package": "server",
-      "function": "splitCSV",
-      "file": "complytime-providers/cmd/ampel-provider/server/server.go",
-      "line": 238,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "server",
-      "function": "validateTargetVariables",
-      "file": "complytime-providers/cmd/ampel-provider/server/server.go",
-      "line": 253,
-      "complexity": 11,
-      "line_coverage": 0,
-      "crap": 132,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "server",
-      "function": "checkRequiredTools",
-      "file": "complytime-providers/cmd/ampel-provider/server/server.go",
-      "line": 296,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "targets",
-      "function": "ParseRepoURL",
-      "file": "complytime-providers/cmd/ampel-provider/targets/targets.go",
-      "line": 15,
-      "complexity": 9,
-      "line_coverage": 0,
-      "crap": 90,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "targets",
-      "function": "SanitizeRepoURL",
-      "file": "complytime-providers/cmd/ampel-provider/targets/targets.go",
-      "line": 59,
-      "complexity": 7,
-      "line_coverage": 0,
-      "crap": 56,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "targets",
-      "function": "RepoDisplayName",
-      "file": "complytime-providers/cmd/ampel-provider/targets/targets.go",
-      "line": 80,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "toolcheck",
-      "function": "CheckTools",
-      "file": "complytime-providers/cmd/ampel-provider/toolcheck/toolcheck.go",
-      "line": 14,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "toolcheck",
-      "function": "FormatMissingToolsError",
-      "file": "complytime-providers/cmd/ampel-provider/toolcheck/toolcheck.go",
-      "line": 26,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "config",
-      "function": "EnsureDirectories",
-      "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-      "line": 40,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "config",
-      "function": "ResolveDatastream",
-      "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-      "line": 58,
-      "complexity": 6,
-      "line_coverage": 0,
-      "crap": 42,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "config",
-      "function": "SanitizeInput",
-      "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-      "line": 80,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "config",
-      "function": "SanitizePath",
-      "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-      "line": 88,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "config",
-      "function": "IsXMLFile",
-      "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-      "line": 97,
-      "complexity": 5,
-      "line_coverage": 0,
-      "crap": 30,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "config",
-      "function": "expandPath",
-      "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-      "line": 116,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "config",
-      "function": "validatePath",
-      "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-      "line": 127,
-      "complexity": 6,
-      "line_coverage": 0,
-      "crap": 42,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "config",
-      "function": "ensureDirectory",
-      "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-      "line": 143,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "config",
-      "function": "getDistroIdsAndVersions",
-      "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-      "line": 157,
-      "complexity": 9,
-      "line_coverage": 0,
-      "crap": 90,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "config",
-      "function": "findMatchingDatastream",
-      "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-      "line": 195,
-      "complexity": 10,
-      "line_coverage": 0,
-      "crap": 110,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "main",
-      "function": "main",
-      "file": "complytime-providers/cmd/openscap-provider/main.go",
-      "line": 10,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "oscap",
-      "function": "shellJoin",
-      "file": "complytime-providers/cmd/openscap-provider/oscap/oscap.go",
-      "line": 17,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "oscap",
-      "function": "executeCommand",
-      "file": "complytime-providers/cmd/openscap-provider/oscap/oscap.go",
-      "line": 21,
-      "complexity": 6,
-      "line_coverage": 0,
-      "crap": 42,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "oscap",
-      "function": "constructScanCommand",
-      "file": "complytime-providers/cmd/openscap-provider/oscap/oscap.go",
-      "line": 51,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "oscap",
-      "function": "OscapScan",
-      "file": "complytime-providers/cmd/openscap-provider/oscap/oscap.go",
-      "line": 71,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "oscap",
-      "function": "constructGenerateFixCommand",
-      "file": "complytime-providers/cmd/openscap-provider/oscap/oscap.go",
-      "line": 77,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "oscap",
-      "function": "OscapGenerateFix",
-      "file": "complytime-providers/cmd/openscap-provider/oscap/oscap.go",
-      "line": 93,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "scan",
-      "function": "validateOpenSCAPFiles",
-      "file": "complytime-providers/cmd/openscap-provider/scan/scan.go",
-      "line": 15,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "scan",
-      "function": "ScanSystem",
-      "file": "complytime-providers/cmd/openscap-provider/scan/scan.go",
-      "line": 35,
-      "complexity": 4,
-      "line_coverage": 42.10526315789474,
-      "crap": 7.104825776352238
-    },
-    {
-      "package": "server",
-      "function": "New",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 34,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "server",
-      "function": "(*ProviderServer).Describe",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 38,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "server",
-      "function": "(*ProviderServer).Generate",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 46,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "server",
-      "function": "generateArtifacts",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 56,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "server",
-      "function": "resolveProfileAndDatastream",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 69,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "server",
-      "function": "executeGeneration",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 84,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "server",
-      "function": "writeTailoringFile",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 101,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "server",
-      "function": "(*ProviderServer).Scan",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 119,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "server",
-      "function": "runScanAndParseARF",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 136,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "server",
-      "function": "parseARFFile",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 156,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "server",
-      "function": "buildAssessmentsFromARF",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 170,
-      "complexity": 5,
-      "line_coverage": 0,
-      "crap": 30,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "server",
-      "function": "assessmentFromRuleResult",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 193,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "server",
-      "function": "resolveRuleResult",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 202,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "server",
-      "function": "isSkippableResult",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 220,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "server",
-      "function": "buildAssessmentLog",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 224,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "server",
-      "function": "findOVALCheckContentRef",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 254,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "server",
-      "function": "mergeVariables",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 265,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "server",
-      "function": "parseCheck",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 276,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "server",
-      "function": "ruleResultMessage",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 293,
-      "complexity": 8,
-      "line_coverage": 0,
-      "crap": 72,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "server",
-      "function": "mapResultStatus",
-      "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-      "line": 319,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "loadDataStream",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 41,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "xccdf",
-      "function": "getDsProfileID",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 56,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "getDsRuleID",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 60,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "getDsVarID",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 64,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "getDsElement",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 68,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "xccdf",
-      "function": "getDsElementAttrValue",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 76,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "xccdf",
-      "function": "getDsOptionalAttrValue",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 85,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "xccdf",
-      "function": "getDsElements",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 93,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "xccdf",
-      "function": "getDsProfile",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 100,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "getDsElementTitle",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 104,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "xccdf",
-      "function": "getDsElementDescription",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 112,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "xccdf",
-      "function": "populateProfileInfo",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 120,
-      "complexity": 7,
-      "line_coverage": 0,
-      "crap": 56,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "populateProfileVariables",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 158,
-      "complexity": 6,
-      "line_coverage": 0,
-      "crap": 42,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "populateProfileRules",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 186,
-      "complexity": 7,
-      "line_coverage": 0,
-      "crap": 56,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "initProfile",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 218,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "GetDsProfile",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 240,
-      "complexity": 5,
-      "line_coverage": 0,
-      "crap": 30,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "GetDsVariablesValues",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 264,
-      "complexity": 10,
-      "line_coverage": 0,
-      "crap": 110,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "getValueFromOption",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 320,
-      "complexity": 5,
-      "line_coverage": 0,
-      "crap": 30,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "ResolveDsVariableOptions",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 333,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "xccdf",
-      "function": "GetDsRules",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 344,
-      "complexity": 9,
-      "line_coverage": 0,
-      "crap": 90,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "NewRuleHashTable",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 393,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "newHashTableFromRootAndQuery",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 397,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "newByIdHashTable",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-      "line": 407,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
-    },
-    {
-      "package": "xccdf",
-      "function": "removePrefix",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 23,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "getTailoringID",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 27,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "getTailoringExtendedProfileID",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 31,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "getTailoringProfileID",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 36,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "getTailoringProfileTitle",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 41,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "getTailoringVersion",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 45,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "getTailoringBenchmarkHref",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 52,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "validateRuleExistence",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 58,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "xccdf",
-      "function": "validateVariableExistence",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 68,
-      "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
-    },
-    {
-      "package": "xccdf",
-      "function": "unselectAbsentRules",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 78,
-      "complexity": 6,
-      "line_coverage": 0,
-      "crap": 42,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "selectAdditionalRules",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 98,
-      "complexity": 7,
-      "line_coverage": 0,
-      "crap": 56,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "filterValidRules",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 124,
-      "complexity": 5,
-      "line_coverage": 0,
-      "crap": 30,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "getTailoringSelections",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 149,
-      "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
-    },
-    {
-      "package": "xccdf",
-      "function": "updateTailoringValues",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 157,
-      "complexity": 8,
-      "line_coverage": 0,
-      "crap": 72,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "getTailoringValues",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 185,
-      "complexity": 6,
-      "line_coverage": 0,
-      "crap": 42,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "getTailoringProfile",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 210,
-      "complexity": 5,
-      "line_coverage": 0,
-      "crap": 30,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "xccdf",
-      "function": "PolicyToXML",
-      "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-      "line": 244,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
     },
     {
       "package": "cache",
@@ -3095,6 +1985,18 @@
       "quadrant": "Q1_Safe"
     },
     {
+      "package": "output",
+      "function": "FormatOperationalWarnings",
+      "file": "internal/output/scan_summary.go",
+      "line": 144,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
+    },
+    {
       "package": "policy",
       "function": "ExtractAssessmentConfigs",
       "file": "internal/policy/assessment.go",
@@ -3755,7 +2657,7 @@
       "package": "provider",
       "function": "(*Client).Close",
       "file": "pkg/provider/client.go",
-      "line": 139,
+      "line": 142,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -3764,7 +2666,7 @@
       "package": "provider",
       "function": "(*Client).Describe",
       "file": "pkg/provider/client.go",
-      "line": 145,
+      "line": 148,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -3773,7 +2675,7 @@
       "package": "provider",
       "function": "(*Client).Generate",
       "file": "pkg/provider/client.go",
-      "line": 163,
+      "line": 166,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -3782,7 +2684,7 @@
       "package": "provider",
       "function": "(*Client).Scan",
       "file": "pkg/provider/client.go",
-      "line": 188,
+      "line": 191,
       "complexity": 5,
       "line_coverage": 0,
       "crap": 30,
@@ -3792,7 +2694,7 @@
       "package": "provider",
       "function": "(*Client).Export",
       "file": "pkg/provider/client.go",
-      "line": 225,
+      "line": 231,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -3801,7 +2703,7 @@
       "package": "provider",
       "function": "protoResultToInternal",
       "file": "pkg/provider/client.go",
-      "line": 244,
+      "line": 250,
       "complexity": 5,
       "line_coverage": 0,
       "crap": 30,
@@ -3811,7 +2713,7 @@
       "package": "provider",
       "function": "protoConfidenceToInternal",
       "file": "pkg/provider/client.go",
-      "line": 259,
+      "line": 265,
       "complexity": 5,
       "line_coverage": 0,
       "crap": 30,
@@ -3935,18 +2837,36 @@
     },
     {
       "package": "provider",
+      "function": "(*ScanResult).HasErrors",
+      "file": "pkg/provider/manager.go",
+      "line": 190,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "provider",
       "function": "(*Manager).RouteScan",
       "file": "pkg/provider/manager.go",
-      "line": 177,
+      "line": 202,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "provider",
+      "function": "(*Manager).RouteScanResult",
+      "file": "pkg/provider/manager.go",
+      "line": 218,
       "complexity": 6,
-      "line_coverage": 82.6086956521739,
-      "crap": 6.189364674940413
+      "line_coverage": 100,
+      "crap": 6
     },
     {
       "package": "provider",
       "function": "(*Manager).scanErrorMessage",
       "file": "pkg/provider/manager.go",
-      "line": 217,
+      "line": 268,
       "complexity": 2,
       "line_coverage": 75,
       "crap": 2.0625
@@ -3955,7 +2875,7 @@
       "package": "provider",
       "function": "(*Manager).RouteExport",
       "file": "pkg/provider/manager.go",
-      "line": 229,
+      "line": 280,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -3964,7 +2884,7 @@
       "package": "provider",
       "function": "(*Manager).resolveExporter",
       "file": "pkg/provider/manager.go",
-      "line": 242,
+      "line": 293,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -3974,7 +2894,7 @@
       "package": "provider",
       "function": "errorAssessments",
       "file": "pkg/provider/manager.go",
-      "line": 257,
+      "line": 308,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -4038,7 +2958,7 @@
       "package": "provider",
       "function": "(*grpcServer).Export",
       "file": "pkg/provider/server.go",
-      "line": 97,
+      "line": 100,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -4048,7 +2968,7 @@
       "package": "provider",
       "function": "internalResultToProto",
       "file": "pkg/provider/server.go",
-      "line": 129,
+      "line": 132,
       "complexity": 5,
       "line_coverage": 0,
       "crap": 30,
@@ -4058,7 +2978,7 @@
       "package": "provider",
       "function": "internalConfidenceToProto",
       "file": "pkg/provider/server.go",
-      "line": 144,
+      "line": 147,
       "complexity": 5,
       "line_coverage": 0,
       "crap": 30,
@@ -4308,25 +3228,25 @@
     }
   ],
   "summary": {
-    "total_functions": 451,
-    "avg_complexity": 3.529933481152993,
-    "avg_line_coverage": 22.771667707239114,
-    "avg_crap": 16.607681366064725,
-    "crapload": 121,
+    "total_functions": 337,
+    "avg_complexity": 3.3857566765578637,
+    "avg_line_coverage": 32.77044958601811,
+    "avg_crap": 12.060490353597672,
+    "crapload": 64,
     "crap_threshold": 15,
     "gaze_crapload": 3,
     "gaze_crap_threshold": 15,
-    "avg_gaze_crap": 6.138888888888888,
-    "avg_contract_coverage": 81.34920634920634,
+    "avg_gaze_crap": 6.089147286821705,
+    "avg_contract_coverage": 81.7829457364341,
     "quadrant_counts": {
-      "Q1_Safe": 39,
+      "Q1_Safe": 40,
       "Q3_SimpleButUnderspecified": 1,
       "Q4_Dangerous": 2
     },
     "fix_strategy_counts": {
-      "add_tests": 116,
+      "add_tests": 61,
       "decompose": 2,
-      "decompose_and_test": 3
+      "decompose_and_test": 1
     },
     "worst_crap": [
       {
@@ -4340,43 +3260,43 @@
         "fix_strategy": "decompose_and_test"
       },
       {
-        "package": "server",
-        "function": "(*ProviderServer).Scan",
-        "file": "complytime-providers/cmd/ampel-provider/server/server.go",
-        "line": 118,
-        "complexity": 17,
-        "line_coverage": 0,
-        "crap": 306,
-        "fix_strategy": "decompose_and_test"
-      },
-      {
-        "package": "results",
-        "function": "ParseAmpelOutput",
-        "file": "complytime-providers/cmd/ampel-provider/results/results.go",
-        "line": 90,
-        "complexity": 16,
-        "line_coverage": 0,
-        "crap": 272,
-        "fix_strategy": "decompose_and_test"
-      },
-      {
-        "package": "scan",
-        "function": "ScanRepository",
-        "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-        "line": 243,
+        "package": "cli",
+        "function": "runDoctor",
+        "file": "cmd/complyctl/cli/doctor.go",
+        "line": 69,
         "complexity": 11,
         "line_coverage": 0,
         "crap": 132,
         "fix_strategy": "add_tests"
       },
       {
-        "package": "server",
-        "function": "validateTargetVariables",
-        "file": "complytime-providers/cmd/ampel-provider/server/server.go",
-        "line": 253,
-        "complexity": 11,
+        "package": "cachetest",
+        "function": "(*MockPolicySource).CopyPolicy",
+        "file": "internal/cache/cachetest/mock_source.go",
+        "line": 73,
+        "complexity": 10,
         "line_coverage": 0,
-        "crap": 132,
+        "crap": 110,
+        "fix_strategy": "add_tests"
+      },
+      {
+        "package": "cli",
+        "function": "promptTargets",
+        "file": "cmd/complyctl/cli/init.go",
+        "line": 149,
+        "complexity": 10,
+        "line_coverage": 0,
+        "crap": 110,
+        "fix_strategy": "add_tests"
+      },
+      {
+        "package": "terminal",
+        "function": "ShowPlainTable",
+        "file": "internal/terminal/table.go",
+        "line": 19,
+        "complexity": 10,
+        "line_coverage": 0,
+        "crap": 110,
         "fix_strategy": "add_tests"
       }
     ],
@@ -4446,24 +3366,6 @@
     ],
     "recommended_actions": [
       {
-        "function": "ScanRepository",
-        "package": "scan",
-        "file": "complytime-providers/cmd/ampel-provider/scan/scan.go",
-        "line": 243,
-        "fix_strategy": "add_tests",
-        "crap": 132,
-        "complexity": 11
-      },
-      {
-        "function": "validateTargetVariables",
-        "package": "server",
-        "file": "complytime-providers/cmd/ampel-provider/server/server.go",
-        "line": 253,
-        "fix_strategy": "add_tests",
-        "crap": 132,
-        "complexity": 11
-      },
-      {
         "function": "runDoctor",
         "package": "cli",
         "file": "cmd/complyctl/cli/doctor.go",
@@ -4473,37 +3375,10 @@
         "complexity": 11
       },
       {
-        "function": "promptTargets",
-        "package": "cli",
-        "file": "cmd/complyctl/cli/init.go",
-        "line": 149,
-        "fix_strategy": "add_tests",
-        "crap": 110,
-        "complexity": 10
-      },
-      {
-        "function": "(*ProviderServer).Generate",
-        "package": "server",
-        "file": "complytime-providers/cmd/ampel-provider/server/server.go",
-        "line": 54,
-        "fix_strategy": "add_tests",
-        "crap": 110,
-        "complexity": 10
-      },
-      {
-        "function": "findMatchingDatastream",
-        "package": "config",
-        "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-        "line": 195,
-        "fix_strategy": "add_tests",
-        "crap": 110,
-        "complexity": 10
-      },
-      {
-        "function": "GetDsVariablesValues",
-        "package": "xccdf",
-        "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-        "line": 264,
+        "function": "ShowPlainTable",
+        "package": "terminal",
+        "file": "internal/terminal/table.go",
+        "line": 19,
         "fix_strategy": "add_tests",
         "crap": 110,
         "complexity": 10
@@ -4518,40 +3393,13 @@
         "complexity": 10
       },
       {
-        "function": "ShowPlainTable",
-        "package": "terminal",
-        "file": "internal/terminal/table.go",
-        "line": 19,
+        "function": "promptTargets",
+        "package": "cli",
+        "file": "cmd/complyctl/cli/init.go",
+        "line": 149,
         "fix_strategy": "add_tests",
         "crap": 110,
         "complexity": 10
-      },
-      {
-        "function": "ToScanResponse",
-        "package": "results",
-        "file": "complytime-providers/cmd/ampel-provider/results/results.go",
-        "line": 195,
-        "fix_strategy": "add_tests",
-        "crap": 90,
-        "complexity": 9
-      },
-      {
-        "function": "GetDsRules",
-        "package": "xccdf",
-        "file": "complytime-providers/cmd/openscap-provider/xccdf/datastream.go",
-        "line": 344,
-        "fix_strategy": "add_tests",
-        "crap": 90,
-        "complexity": 9
-      },
-      {
-        "function": "ParseRepoURL",
-        "package": "targets",
-        "file": "complytime-providers/cmd/ampel-provider/targets/targets.go",
-        "line": 15,
-        "fix_strategy": "add_tests",
-        "crap": 90,
-        "complexity": 9
       },
       {
         "function": "main",
@@ -4563,33 +3411,6 @@
         "complexity": 9
       },
       {
-        "function": "getDistroIdsAndVersions",
-        "package": "config",
-        "file": "complytime-providers/cmd/openscap-provider/config/config.go",
-        "line": 157,
-        "fix_strategy": "add_tests",
-        "crap": 90,
-        "complexity": 9
-      },
-      {
-        "function": "LoadGranularPolicies",
-        "package": "convert",
-        "file": "complytime-providers/cmd/ampel-provider/convert/convert.go",
-        "line": 20,
-        "fix_strategy": "add_tests",
-        "crap": 90,
-        "complexity": 9
-      },
-      {
-        "function": "DigestRecordedInState",
-        "package": "behavioral",
-        "file": "tests/behavioral/supply_chain.go",
-        "line": 50,
-        "fix_strategy": "add_tests",
-        "crap": 72,
-        "complexity": 8
-      },
-      {
         "function": "CheckProviders",
         "package": "doctor",
         "file": "internal/doctor/doctor.go",
@@ -4599,19 +3420,10 @@
         "complexity": 8
       },
       {
-        "function": "ruleResultMessage",
-        "package": "server",
-        "file": "complytime-providers/cmd/openscap-provider/server/server.go",
-        "line": 293,
-        "fix_strategy": "add_tests",
-        "crap": 72,
-        "complexity": 8
-      },
-      {
-        "function": "updateTailoringValues",
-        "package": "xccdf",
-        "file": "complytime-providers/cmd/openscap-provider/xccdf/tailoring.go",
-        "line": 157,
+        "function": "DigestRecordedInState",
+        "package": "behavioral",
+        "file": "tests/behavioral/supply_chain.go",
+        "line": 50,
         "fix_strategy": "add_tests",
         "crap": 72,
         "complexity": 8
@@ -4624,6 +3436,114 @@
         "fix_strategy": "add_tests",
         "crap": 56,
         "complexity": 7
+      },
+      {
+        "function": "PluginBinaryIntegrityCheck",
+        "package": "behavioral",
+        "file": "tests/behavioral/plugin_security.go",
+        "line": 67,
+        "fix_strategy": "add_tests",
+        "crap": 56,
+        "complexity": 7
+      },
+      {
+        "function": "promptPolicies",
+        "package": "cli",
+        "file": "cmd/complyctl/cli/init.go",
+        "line": 106,
+        "fix_strategy": "add_tests",
+        "crap": 56,
+        "complexity": 7
+      },
+      {
+        "function": "InstallTestPlugin",
+        "package": "behavioral",
+        "file": "tests/behavioral/reusable_steps.go",
+        "line": 57,
+        "fix_strategy": "add_tests",
+        "crap": 56,
+        "complexity": 7
+      },
+      {
+        "function": "OSCALResultProduced",
+        "package": "behavioral",
+        "file": "tests/behavioral/audit.go",
+        "line": 48,
+        "fix_strategy": "add_tests",
+        "crap": 56,
+        "complexity": 7
+      },
+      {
+        "function": "(*Cache).ListPolicies",
+        "package": "cache",
+        "file": "internal/cache/cache.go",
+        "line": 50,
+        "fix_strategy": "add_tests",
+        "crap": 56,
+        "complexity": 7
+      },
+      {
+        "function": "suggestCachedPolicyIDs",
+        "package": "cli",
+        "file": "cmd/complyctl/cli/get.go",
+        "line": 145,
+        "fix_strategy": "add_tests",
+        "crap": 42,
+        "complexity": 6
+      },
+      {
+        "function": "serveManifest",
+        "package": "main",
+        "file": "cmd/mock-oci-registry/main.go",
+        "line": 148,
+        "fix_strategy": "add_tests",
+        "crap": 42,
+        "complexity": 6
+      },
+      {
+        "function": "registerOCIRoutes",
+        "package": "main",
+        "file": "cmd/mock-oci-registry/main.go",
+        "line": 70,
+        "fix_strategy": "add_tests",
+        "crap": 42,
+        "complexity": 6
+      },
+      {
+        "function": "HTTPSchemeRejected",
+        "package": "behavioral",
+        "file": "tests/behavioral/transport_security.go",
+        "line": 17,
+        "fix_strategy": "add_tests",
+        "crap": 42,
+        "complexity": 6
+      },
+      {
+        "function": "EvaluationLogProduced",
+        "package": "behavioral",
+        "file": "tests/behavioral/audit.go",
+        "line": 17,
+        "fix_strategy": "add_tests",
+        "crap": 42,
+        "complexity": 6
+      },
+      {
+        "function": "LoadFrom",
+        "package": "complytime",
+        "file": "internal/complytime/config.go",
+        "line": 164,
+        "fix_strategy": "add_tests",
+        "crap": 30,
+        "complexity": 5
+      },
+      {
+        "function": "(*Client).Scan",
+        "package": "provider",
+        "file": "pkg/provider/client.go",
+        "line": 191,
+        "fix_strategy": "add_tests",
+        "crap": 30,
+        "complexity": 5
       }
     ]
   }

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   call_reusable_ci:
     name: Standardized CI
-    uses: complytime/org-infra/.github/workflows/reusable_ci.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_ci.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     permissions:
       contents: read
       issues: read

--- a/.github/workflows/ci_compliance.yml
+++ b/.github/workflows/ci_compliance.yml
@@ -24,7 +24,7 @@ jobs:
     name: Compliance Evaluation
     permissions:
       contents: read
-    uses: complytime/org-infra/.github/workflows/reusable_compliance.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_compliance.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       complytime_config_path: ${{ inputs.complytime_config_path || 'complytime.yaml' }}
       policy_id: ${{ inputs.policy_id || 'ampel-bp' }}

--- a/.github/workflows/ci_crapload.yml
+++ b/.github/workflows/ci_crapload.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   crapload:
     name: CRAP Load Analysis
-    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     permissions:
       contents: read
 

--- a/.github/workflows/ci_crapload_main.yml
+++ b/.github/workflows/ci_crapload_main.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
     crapload-analysis:
         name: Full CRAP Load Analysis
-        uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+        uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
         permissions:
             contents: read
         with:

--- a/.github/workflows/ci_dependencies.yml
+++ b/.github/workflows/ci_dependencies.yml
@@ -25,11 +25,11 @@ env:
 jobs:
   call_deps_reviewer:
     name: General
-    uses: complytime/org-infra/.github/workflows/reusable_deps_reviewer.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_deps_reviewer.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
 
   call_dependabot_reviewer:
     name: Dependabot
-    uses: complytime/org-infra/.github/workflows/reusable_dependabot_reviewer.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_dependabot_reviewer.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
 
   comment_on_dependabot_prs:
     name: Dependabot Comment

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -18,4 +18,4 @@ jobs:
       actions: read           # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
       security-events: write  # Require writing security events to upload SARIF file to security tab
       id-token: write         # Needed to access GitHub's OIDC token which verifies the authenticity of the result when publishing it.
-    uses: complytime/org-infra/.github/workflows/reusable_scheduled.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_scheduled.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1

--- a/.github/workflows/ci_security.yml
+++ b/.github/workflows/ci_security.yml
@@ -24,7 +24,7 @@ jobs:
       security-events: write
       packages: write
       id-token: write
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       # OSV focuses on known CVEs in dependencies; Trivy adds broader coverage
       enable_trivy_source: true
@@ -35,4 +35,4 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    uses: complytime/org-infra/.github/workflows/reusable_security.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_security.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1

--- a/.github/workflows/ci_sonarcloud.yml
+++ b/.github/workflows/ci_sonarcloud.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
       pull-requests: read
     needs: generate-coverage
-    uses: complytime/org-infra/.github/workflows/reusable_sonarqube.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_sonarqube.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       sonar_organization: ${{ vars.SONAR_ORGANIZATION }}
       sonar_project_key: ${{ vars.SONAR_PROJECT_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
               uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
             - name: Run GoReleaser
-              uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+              uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
               with:
                   version: '~> v2'
                   args: --verbose release --clean

--- a/cmd/behavioral-report/main.go
+++ b/cmd/behavioral-report/main.go
@@ -166,7 +166,7 @@ func writeEvaluationLog(evalLog gemara.EvaluationLog, outDir string) error {
 }
 
 func writeSARIF(evalLog gemara.EvaluationLog, artifactURI, outDir string, catalog *gemara.ControlCatalog) error {
-	sarifBytes, err := gemaraconv.ToSARIF(evalLog, artifactURI, catalog)
+	sarifBytes, err := gemaraconv.ToSARIF(evalLog, gemaraconv.WithArtifactURI(artifactURI), gemaraconv.WithCatalog(catalog))
 	if err != nil {
 		return fmt.Errorf("SARIF conversion: %w", err)
 	}

--- a/complytime.yaml
+++ b/complytime.yaml
@@ -1,5 +1,5 @@
 policies:
-  - url: http://localhost:8765/policies/ampel-branch-protection
+  - url: quay.io/complytime/policies-ampel-branch-protection:latest
     id: ampel-bp
 
 targets:

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -56,7 +56,7 @@ targets:
 
 ```yaml
 policies:
-  - url: quay.io/complytime/complytime-policies@ampel-branch-protection
+  - url: quay.io/complytime/policies-ampel-branch-protection:latest
     id: ampel-bp
 
 targets:
@@ -74,7 +74,7 @@ See the [ampel provider configuration](https://github.com/complytime/complytime-
 
 ```yaml
 policies:
-  - url: quay.io/complytime/complytime-policies@cis-fedora-l1-workstation
+  - url: quay.io/complytime/policies-cis-fedora-l1-workstation:latest
     id: cis-fedora-l1
 
 targets:

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -10,32 +10,79 @@ Scanning providers are standalone executables placed in `~/.complytime/providers
 
 ```bash
 mkdir -p ~/.complytime/providers
-cp bin/complyctl-provider-openscap ~/.complytime/providers/
+cp bin/complyctl-provider-<name> ~/.complytime/providers/
 ```
 
 Naming convention: `complyctl-provider-<evaluator-id>`. The CLI strips the prefix to derive the evaluator ID used for routing.
 
-For the openscap provider, install prerequisites:
-- `openscap-scanner` package
-- `scap-security-guide` package
+### Available providers
+
+| Provider | Binary | What it evaluates | Prerequisites |
+|----------|--------|-------------------|---------------|
+| [openscap](https://github.com/complytime/complytime-providers/blob/main/cmd/openscap-provider/docs/configuration.md) | `complyctl-provider-openscap` | SCAP policies (CIS, STIG, HIPAA, OSPP, etc.) | `openscap-scanner`, `scap-security-guide` |
+| [ampel](https://github.com/complytime/complytime-providers/tree/main/cmd/ampel-provider) | `complyctl-provider-ampel` | GitHub / GitLab branch protection | `snappy`, `ampel`, `GITHUB_TOKEN` or `GITLAB_TOKEN` |
 
 See the [Provider Guide](https://github.com/complytime/complytime-providers/blob/main/docs/provider-guide.md) for authoring details.
 
 ## Step 3: Create workspace config
 
-Create `complytime.yaml` in your working directory. This is the runtime configuration — it declares targets, variables, and policy selections.
+Create `complytime.yaml` in your working directory. This is the runtime configuration — it declares policies, targets, and variables.
 
 ```yaml
-version: 1
 policies:
-  - url: registry.example.com/policies/nist-800-53-r5@v1.0
-    id: nist
+  - url: <oci-reference>
+    id: <short-alias>
+
+variables:
+  key: value
+
+targets:
+  - id: <target-id>
+    policies:
+      - <policy-id>
+    variables:
+      key: value
+```
+
+| Section | Purpose |
+|---------|---------|
+| `policies` | OCI references to Gemara policy bundles. `id` is a short alias used by targets and for provider routing. |
+| `variables` | Workspace-scoped constants passed to all providers (e.g., custom policy directories). |
+| `targets` | Systems to evaluate. Each target selects one or more policies and provides provider-specific variables. |
+
+**Variable expansion**: Only `targets[].variables` supports `${VAR}` environment variable substitution. Use this for secrets and per-target credentials. Top-level `variables` are workspace constants passed to providers as-is — `${...}` references there are **not** expanded.
+
+### Example: ampel branch protection
+
+```yaml
+policies:
+  - url: quay.io/complytime/complytime-policies@ampel-branch-protection
+    id: ampel-bp
+
+targets:
+  - id: my-repo
+    policies:
+      - ampel-bp
+    variables:
+      url: https://github.com/myorg/myrepo
+      specs: builtin:github/branch-rules.yaml
+```
+
+See the [ampel provider configuration](https://github.com/complytime/complytime-providers/blob/main/cmd/ampel-provider/docs/configuration.md) for all target variables.
+
+### Example: CIS Fedora L1 (OpenSCAP)
+
+```yaml
+policies:
+  - url: quay.io/complytime/complytime-policies@cis-fedora-l1-workstation
+    id: cis-fedora-l1
+
 targets:
   - id: my-system
     policies:
-      - nist
+      - cis-fedora-l1
     variables:
-      api_token: ${MY_API_TOKEN}
+      profile: xccdf_org.ssgproject.content_profile_cis_workstation_l1
 ```
 
 Or use interactive setup:
@@ -46,7 +93,7 @@ complyctl init
 
 `init` prompts for policy URLs, IDs, and targets when no `complytime.yaml` exists.
 
-**Variable expansion**: Only `targets[].variables` supports `${VAR}` environment variable substitution. Use this for secrets and per-target credentials. Top-level `variables` are workspace constants passed to providers as-is — `${...}` references there are **not** expanded.
+Available policy bundles are listed in the [complytime-policies usage guide](https://github.com/complytime/complytime-policies/blob/main/docs/usage.md).
 
 ## Step 4: Fetch policies
 
@@ -67,33 +114,52 @@ Displays cached policies and their versions.
 ## Step 6: Generate
 
 ```bash
-complyctl generate --policy-id nist-800-53-r5
+complyctl generate --policy-id ampel-bp
 ```
 
 Resolves the policy dependency graph, extracts assessment configurations, and dispatches to the matching provider via Generate RPC.
 
 ## Step 7: Scan
 
+Scan all targets for a policy:
+
 ```bash
 # EvaluationLog (default)
-complyctl scan --policy-id nist-800-53-r5
+complyctl scan --policy-id ampel-bp
 
 # Markdown report
-complyctl scan --policy-id nist-800-53-r5 --format pretty
+complyctl scan --policy-id ampel-bp --format pretty
 
 # OSCAL assessment-results
-complyctl scan --policy-id nist-800-53-r5 --format oscal
+complyctl scan --policy-id ampel-bp --format oscal
 
 # SARIF
-complyctl scan --policy-id nist-800-53-r5 --format sarif
+complyctl scan --policy-id ampel-bp --format sarif
 ```
+
+Or scan a single target (policy is inferred when the target has exactly one):
+
+```bash
+complyctl scan my-repo
+```
+
+`complyctl scan` automatically calls `generate` if artifacts are missing or the policy digest has changed.
 
 Output written to `./.complytime/scan/`.
 
 ## Authentication
 
-complyctl uses Docker credential helpers via `oras-credentials-go`. No custom configuration needed — if `docker login` works, `complyctl get` works.
+**OCI registry:** complyctl uses Docker credential helpers via `oras-credentials-go`. No custom configuration needed — if `docker login` works, `complyctl get` works.
 
 Supported sources:
 - `~/.docker/config.json` (credHelpers, credsStore, inline auths)
 - Credential helpers: `docker-credential-desktop`, `docker-credential-gcloud`, `docker-credential-ecr-login`, etc.
+
+**GitHub / GitLab API (ampel provider):** Set the appropriate token before scanning:
+
+```bash
+export GITHUB_TOKEN=ghp_your_token_here   # GitHub
+export GITLAB_TOKEN=glpat-your_token_here  # GitLab
+```
+
+Per-repository tokens can also be configured via the `access_token` target variable. See the [ampel provider configuration](https://github.com/complytime/complytime-providers/blob/main/cmd/ampel-provider/docs/configuration.md) for details.

--- a/docs/adr/0001-one-quay-repo-per-bundle.md
+++ b/docs/adr/0001-one-quay-repo-per-bundle.md
@@ -1,0 +1,47 @@
+# ADR-0001: One Quay Repository Per Policy Bundle
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Canonical Location:** [complytime-policies/docs/adr/0001-one-quay-repo-per-bundle.md](https://github.com/complytime/complytime-policies/blob/main/docs/adr/0001-one-quay-repo-per-bundle.md)
+
+## Summary
+
+Policy bundles published from `complytime-policies` will each get their
+own Quay.io repository with a `policies-` prefix (e.g.,
+`quay.io/complytime/policies-ampel-branch-protection`) instead of sharing
+a single repository with bundle-name tags.
+
+## Impact on complyctl
+
+**None.** `complyctl` treats `complytime.yaml` URLs as opaque OCI
+references. The `ParsePolicyRef` and registry client code already
+support any valid OCI reference format — single-repo or multi-repo.
+
+### Consumer configuration change
+
+Before (single repo, bundle-name tag):
+
+```yaml
+policies:
+  - id: ampel-branch-protection
+    url: quay.io/complytime/complytime-policies@ampel-branch-protection
+```
+
+After (per-bundle repo with policies- prefix, version tag):
+
+```yaml
+policies:
+  - id: ampel-branch-protection
+    url: quay.io/complytime/policies-ampel-branch-protection:latest
+```
+
+### Documentation updates needed
+
+- `docs/QUICK_START.md` — update OCI reference examples
+- README policy reference examples (if any)
+
+## Full Decision Record
+
+See the canonical ADR in
+[complytime-policies](https://github.com/complytime/complytime-policies/blob/main/docs/adr/0001-one-quay-repo-per-bundle.md)
+for full context, rationale, and alternatives considered.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/charmbracelet/log v1.0.0
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/defenseunicorns/go-oscal v0.7.0
-	github.com/gemaraproj/go-gemara v0.4.0
+	github.com/gemaraproj/go-gemara v0.5.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/gemaraproj/go-gemara v0.4.0 h1:zyn7bJiqAitrRBCDlMYVLb8C1XhDWG2wI0j+pHad3HA=
-github.com/gemaraproj/go-gemara v0.4.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
+github.com/gemaraproj/go-gemara v0.5.0 h1:sKDj3R7fX8tdlksShWGCLUl/sLvo+tGh1xAFs1JaoHU=
+github.com/gemaraproj/go-gemara v0.5.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
 github.com/go-logfmt/logfmt v0.6.1 h1:4hvbpePJKnIzH1B+8OR/JPbTx37NktoI9LE2QZBBkvE=
 github.com/go-logfmt/logfmt v0.6.1/go.mod h1:EV2pOAQoZaT1ZXZbqDl5hrymndi4SY9ED9/z6CO0XAk=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -17,7 +17,7 @@ import (
 
 // ToSARIF converts a gemara.EvaluationLog to SARIF using go-gemara gemaraconv.
 func ToSARIF(log *gemara.EvaluationLog, artifactURI, outDir string) (string, error) {
-	sarifBytes, err := gemaraconv.ToSARIF(*log, artifactURI, nil)
+	sarifBytes, err := gemaraconv.ToSARIF(*log, gemaraconv.WithArtifactURI(artifactURI))
 	if err != nil {
 		return "", fmt.Errorf("SARIF conversion failed: %w", err)
 	}

--- a/vendor/github.com/gemaraproj/go-gemara/.goreleaser.yaml
+++ b/vendor/github.com/gemaraproj/go-gemara/.goreleaser.yaml
@@ -38,6 +38,7 @@ changelog:
       - "^test:"
 
 release:
+  disable: true
   prerelease: auto
 
 universal_binaries:

--- a/vendor/github.com/gemaraproj/go-gemara/Makefile
+++ b/vendor/github.com/gemaraproj/go-gemara/Makefile
@@ -161,6 +161,7 @@ oscal-export:
 	@mkdir -p artifacts
 	@go run ./cmd/oscalexport catalog ./test-data/good-osps.yml --output ./artifacts/catalog.json
 	@go run ./cmd/oscalexport guidance ./test-data/good-aigf.yaml --catalog-output ./artifacts/guidance.json --profile-output ./artifacts/profile.json
+	@go run ./cmd/oscalexport evaluation ./test-data/good-evaluation-log.yaml --output ./artifacts/assessment-results.json --catalog ./test-data/good-osps.yml
 
 help:
 	@echo "make targets:"

--- a/vendor/github.com/gemaraproj/go-gemara/README.md
+++ b/vendor/github.com/gemaraproj/go-gemara/README.md
@@ -185,11 +185,11 @@ func main() {
     }
 
     // Convert EvaluationLog to SARIF
-    evaluationLog := &gemara.EvaluationLog{
+    evaluationLog := gemara.EvaluationLog{
         // ... populate evaluation log ...
     }
 
-    sarifBytes, err := gemaraconv.EvaluationLog(evaluationLog).ToSARIF("file:///path/to/artifact.md", catalog)
+    sarifBytes, err := gemaraconv.EvaluationLog(evaluationLog).ToSARIF(gemaraconv.WithArtifactURI("file:///path/to/artifact.md"), gemaraconv.WithCatalog(catalog))
     if err != nil {
         panic(err)
     }

--- a/vendor/github.com/gemaraproj/go-gemara/fetcher/uri.go
+++ b/vendor/github.com/gemaraproj/go-gemara/fetcher/uri.go
@@ -8,10 +8,18 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strings"
 )
 
-// URI routes to File or HTTP based on the URI scheme.
-// Supported schemes: file://, http://, https://.
+// URI routes to File or HTTP based on the source string.
+//
+// Recognized forms:
+//   - http:// or https:// URLs are fetched via [HTTP].
+//   - file:// URIs are fetched via [File].
+//   - Any other input without a scheme (absolute or relative local paths,
+//     including Windows drive paths) is treated as a local file path.
+//   - Inputs with any other <scheme>:// prefix return an unsupported-scheme error.
 //
 // For HTTP(S) sources it delegates to [HTTP]; see that type's
 // documentation for security considerations.
@@ -19,17 +27,22 @@ type URI struct {
 	Client *http.Client
 }
 
+// schemePrefix matches a leading "<scheme>://" per RFC 3986 scheme syntax.
+var schemePrefix = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.\-]*://`)
+
 func (u *URI) Fetch(ctx context.Context, source string) (io.ReadCloser, error) {
-	parsed, err := url.Parse(source)
-	if err != nil {
-		return nil, fmt.Errorf("invalid URI %q: %w", source, err)
-	}
-	switch parsed.Scheme {
-	case "file":
-		return (&File{}).Fetch(ctx, parsed.Path)
-	case "http", "https":
+	switch {
+	case strings.HasPrefix(source, "http://"), strings.HasPrefix(source, "https://"):
 		return (&HTTP{Client: u.Client}).Fetch(ctx, source)
-	default:
+	case strings.HasPrefix(source, "file://"):
+		parsed, err := url.Parse(source)
+		if err != nil {
+			return nil, fmt.Errorf("invalid file URI %q: %w", source, err)
+		}
+		return (&File{}).Fetch(ctx, parsed.Path)
+	case schemePrefix.MatchString(source):
 		return nil, fmt.Errorf("unsupported URI scheme in %q", source)
+	default:
+		return (&File{}).Fetch(ctx, source)
 	}
 }

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/assessment_results.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/assessment_results.go
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gemaraconv
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/defenseunicorns/go-oscal/src/pkg/uuid"
+	oscal "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
+	"github.com/gemaraproj/go-gemara"
+	oscalUtils "github.com/gemaraproj/go-gemara/internal/oscal"
+)
+
+// EvaluationLogToOSCALAssessmentResults converts a Gemara EvaluationLog into an
+// OSCAL Assessment Results document.
+//
+// Use WithImportApHref to set the assessment plan reference (defaults to "#").
+// Use WithCatalog to enrich findings with control titles and requirement text.
+func EvaluationLogToOSCALAssessmentResults(log gemara.EvaluationLog, opts ...EvalOption) (oscal.AssessmentResults, error) {
+	options := defaultEvalOpts()
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	authorPartyUUID := uuid.NewUUID()
+	metadata := createAssessmentResultsMetadata(log, authorPartyUUID)
+
+	result, err := evaluationLogToResult(log, options.catalog, authorPartyUUID)
+	if err != nil {
+		return oscal.AssessmentResults{}, fmt.Errorf("converting evaluation log %q: %w", log.Metadata.Id, err)
+	}
+
+	return oscal.AssessmentResults{
+		UUID:       uuid.NewUUID(),
+		Metadata:   metadata,
+		ImportAp:   oscal.ImportAp{Href: options.importApHref},
+		Results:    []oscal.Result{result},
+		BackMatter: mappingToBackMatter(log.Metadata.MappingReferences),
+	}, nil
+}
+
+func evaluationLogToResult(log gemara.EvaluationLog, catalog *gemara.ControlCatalog, authorPartyUUID string) (oscal.Result, error) {
+	now := time.Now()
+	start := oscalUtils.GetTimeWithFallback(string(log.Metadata.Date), now)
+
+	origin := buildOrigin(log.Metadata.Author, authorPartyUUID)
+
+	controlIds := collectControlIds(log)
+	reviewedControls := buildReviewedControls(controlIds)
+
+	var observations []oscal.Observation
+	var findings []oscal.Finding
+	var logEntries []oscal.AssessmentLogEntry
+
+	for _, eval := range log.Evaluations {
+		if eval == nil {
+			continue
+		}
+
+		finding := buildFinding(eval, catalog, origin)
+		var relatedObs []oscal.RelatedObservation
+
+		for _, alog := range eval.AssessmentLogs {
+			if alog == nil {
+				continue
+			}
+
+			obs := buildObservation(alog, eval, origin, start)
+			observations = append(observations, obs)
+			relatedObs = append(relatedObs, oscal.RelatedObservation{ObservationUuid: obs.UUID})
+
+			entry := buildLogEntry(alog, eval, authorPartyUUID, start)
+			logEntries = append(logEntries, entry)
+		}
+
+		if len(relatedObs) > 0 {
+			finding.RelatedObservations = &relatedObs
+		}
+		findings = append(findings, finding)
+	}
+
+	title := fmt.Sprintf("Evaluation: %s", log.Metadata.Id)
+
+	targetItem := buildTargetInventoryItem(log.Target)
+	localDefs := oscal.LocalDefinitions{
+		InventoryItems: &[]oscal.InventoryItem{targetItem},
+	}
+
+	result := oscal.Result{
+		UUID:             uuid.NewUUID(),
+		Title:            title,
+		Description:      fmt.Sprintf("Results from Gemara EvaluationLog %s", log.Metadata.Id),
+		Start:            start,
+		ReviewedControls: reviewedControls,
+		Observations:     oscalUtils.NilIfEmpty(observations),
+		Findings:         oscalUtils.NilIfEmpty(findings),
+		LocalDefinitions: &localDefs,
+		Props: &[]oscal.Property{
+			{
+				Name:  "aggregate-result",
+				Value: log.Result.String(),
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+		},
+	}
+
+	if len(logEntries) > 0 {
+		result.AssessmentLog = &oscal.AssessmentLog{Entries: logEntries}
+	}
+
+	return result, nil
+}
+
+func createAssessmentResultsMetadata(log gemara.EvaluationLog, authorPartyUUID string) oscal.Metadata {
+	version := log.Metadata.Version
+	if version == "" {
+		version = oscalUtils.DefaultOSCALVersion
+	}
+
+	now := time.Now()
+	published := oscalUtils.GetTime(string(log.Metadata.Date))
+
+	metadata := oscal.Metadata{
+		Title:        fmt.Sprintf("Assessment Results: %s", log.Metadata.Id),
+		OscalVersion: oscal.Version,
+		Version:      version,
+		Published:    published,
+		LastModified: now,
+	}
+
+	if log.Metadata.Author.Name != "" {
+		authorRole := oscal.Role{
+			ID:    "assessor",
+			Title: "Assessor",
+		}
+		party := oscal.Party{
+			UUID: authorPartyUUID,
+			Type: mapPartyType(log.Metadata.Author.Type),
+			Name: log.Metadata.Author.Name,
+		}
+		metadata.Roles = &[]oscal.Role{authorRole}
+		metadata.Parties = &[]oscal.Party{party}
+		metadata.ResponsibleParties = &[]oscal.ResponsibleParty{
+			{RoleId: authorRole.ID, PartyUuids: []string{party.UUID}},
+		}
+	}
+
+	return metadata
+}
+
+func buildOrigin(author gemara.Actor, partyUUID string) oscal.Origin {
+	return oscal.Origin{
+		Actors: []oscal.OriginActor{
+			{
+				ActorUuid: partyUUID,
+				Type:      mapActorType(author.Type),
+				RoleId:    "assessor",
+			},
+		},
+	}
+}
+
+func buildReviewedControls(controlIds []string) oscal.ReviewedControls {
+	selectors := make([]oscal.AssessedControlsSelectControlById, 0, len(controlIds))
+	for _, id := range controlIds {
+		selectors = append(selectors, oscal.AssessedControlsSelectControlById{ControlId: id})
+	}
+	return oscal.ReviewedControls{
+		ControlSelections: []oscal.AssessedControls{
+			{IncludeControls: &selectors},
+		},
+	}
+}
+
+func buildFinding(eval *gemara.ControlEvaluation, catalog *gemara.ControlCatalog, origin oscal.Origin) oscal.Finding {
+	controlId := eval.Control.EntryId
+	status := mapResultToObjectiveStatus(eval.Result)
+
+	description := eval.Message
+	if description == "" {
+		description = fmt.Sprintf("Evaluation of control %s", controlId)
+	}
+
+	title := eval.Name
+	if catalog != nil {
+		control, _ := findControlAndRequirement(catalog, controlId, "")
+		if control != nil && control.Title != "" {
+			title = control.Title
+		}
+	}
+	if title == "" {
+		title = controlId
+	}
+	title = sanitizeTitle(title)
+
+	return oscal.Finding{
+		UUID:        uuid.NewUUID(),
+		Title:       title,
+		Description: description,
+		Origins:     &[]oscal.Origin{origin},
+		Target: oscal.FindingTarget{
+			Type:     "objective-id",
+			TargetId: controlId,
+			Status:   status,
+		},
+	}
+}
+
+func buildObservation(alog *gemara.AssessmentLog, eval *gemara.ControlEvaluation, origin oscal.Origin, fallback time.Time) oscal.Observation {
+	collected := oscalUtils.GetTimeWithFallback(string(alog.Start), fallback)
+
+	description := alog.Description
+	if description == "" {
+		description = alog.Message
+	}
+	if description == "" {
+		description = fmt.Sprintf("Assessment of requirement %s", alog.Requirement.EntryId)
+	}
+
+	methods := []string{"EXAMINE"}
+	if alog.StepsExecuted > 0 {
+		methods = []string{"TEST"}
+	}
+
+	obs := oscal.Observation{
+		UUID:        uuid.NewUUID(),
+		Description: description,
+		Collected:   collected,
+		Methods:     methods,
+		Origins:     &[]oscal.Origin{origin},
+		Props: &[]oscal.Property{
+			{
+				Name:  "result",
+				Value: alog.Result.String(),
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+			{
+				Name:  "requirement-id",
+				Value: alog.Requirement.EntryId,
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+			{
+				Name:  "control-id",
+				Value: eval.Control.EntryId,
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+		},
+	}
+
+	if alog.Recommendation != "" {
+		obs.Remarks = alog.Recommendation
+	}
+
+	return obs
+}
+
+func buildLogEntry(alog *gemara.AssessmentLog, eval *gemara.ControlEvaluation, partyUUID string, fallback time.Time) oscal.AssessmentLogEntry {
+	start := oscalUtils.GetTimeWithFallback(string(alog.Start), fallback)
+
+	title := fmt.Sprintf("%s / %s", eval.Control.EntryId, alog.Requirement.EntryId)
+
+	entry := oscal.AssessmentLogEntry{
+		UUID:        uuid.NewUUID(),
+		Title:       title,
+		Start:       start,
+		Description: alog.Description,
+		LoggedBy: &[]oscal.LoggedBy{
+			{PartyUuid: partyUUID, RoleId: "assessor"},
+		},
+	}
+
+	if end := oscalUtils.GetTime(string(alog.End)); end != nil {
+		entry.End = end
+	}
+
+	return entry
+}
+
+func buildTargetInventoryItem(target gemara.Resource) oscal.InventoryItem {
+	description := target.Description
+	if description == "" {
+		description = target.Name
+	}
+
+	return oscal.InventoryItem{
+		UUID:        uuid.NewUUID(),
+		Description: description,
+		Props: &[]oscal.Property{
+			{
+				Name:  "gemara-resource-id",
+				Value: target.Id,
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+			{
+				Name:  "name",
+				Value: target.Name,
+				Ns:    oscalUtils.GemaraNamespace,
+			},
+		},
+	}
+}
+
+func collectControlIds(log gemara.EvaluationLog) []string {
+	seen := make(map[string]struct{})
+	var ids []string
+	for _, eval := range log.Evaluations {
+		if eval == nil {
+			continue
+		}
+		id := eval.Control.EntryId
+		if _, exists := seen[id]; !exists {
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func mapResultToObjectiveStatus(r gemara.Result) oscal.ObjectiveStatus {
+	switch r {
+	case gemara.Passed:
+		return oscal.ObjectiveStatus{State: "satisfied"}
+	case gemara.Failed:
+		return oscal.ObjectiveStatus{State: "not-satisfied"}
+	default:
+		return oscal.ObjectiveStatus{
+			State:  "not-satisfied",
+			Reason: r.String(),
+		}
+	}
+}
+
+// sanitizeTitle collapses newlines and surrounding whitespace into a single
+// space so the value satisfies the OSCAL StringDatatype pattern (^[^\n]+$).
+func sanitizeTitle(s string) string {
+	parts := strings.Fields(s)
+	return strings.Join(parts, " ")
+}
+
+func mapActorType(t gemara.EntityType) string {
+	switch t {
+	case gemara.Human:
+		return "person"
+	default:
+		return "tool"
+	}
+}
+
+func mapPartyType(t gemara.EntityType) string {
+	switch t {
+	case gemara.Human:
+		return "person"
+	default:
+		return "organization"
+	}
+}

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/catalog.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/catalog.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CatalogToOSCAL converts a Gemara ControlCatalog to OSCAL Catalog format.
-func CatalogToOSCAL(catalog *gemara.ControlCatalog, opts ...GenerateOption) (oscal.Catalog, error) {
+func CatalogToOSCAL(catalog gemara.ControlCatalog, opts ...GenerateOption) (oscal.Catalog, error) {
 	options := generateOpts{}
 	for _, opt := range opts {
 		opt(&options)

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/catalog_markdown.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/catalog_markdown.go
@@ -2,7 +2,6 @@ package gemaraconv
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gemaraproj/go-gemara"
 	"github.com/gemaraproj/go-gemara/gemaraconv/markdown"
@@ -13,11 +12,7 @@ type InlineLexiconTerm = markdown.InlineLexiconTerm
 
 // CatalogToMarkdown renders a ControlCatalog as Markdown using embedded templates.
 // Only controls whose state is LifecycleActive are included (TOC, body, and summary counts).
-func CatalogToMarkdown(ctx context.Context, catalog *gemara.ControlCatalog, opts ...MarkdownOption) ([]byte, error) {
-	if catalog == nil {
-		return nil, fmt.Errorf("catalog is nil")
-	}
-
+func CatalogToMarkdown(ctx context.Context, catalog gemara.ControlCatalog, opts ...MarkdownOption) ([]byte, error) {
 	o := defaultMarkdownOpts()
 	o.apply(opts...)
 

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/converters.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/converters.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package gemaraconv
 
 import (
@@ -9,26 +11,31 @@ import (
 
 // EvaluationLogConverter define a converter object for converting EvaluationLog.
 type EvaluationLogConverter struct {
-	log *gemara.EvaluationLog
+	log gemara.EvaluationLog
 }
 
 // EvaluationLog creates a new EvaluationLogConverter struct.
-func EvaluationLog(log *gemara.EvaluationLog) *EvaluationLogConverter {
+func EvaluationLog(log gemara.EvaluationLog) *EvaluationLogConverter {
 	return &EvaluationLogConverter{log: log}
 }
 
 // ToSARIF converts the EvaluationLog to SARIF format.
-func (c *EvaluationLogConverter) ToSARIF(artifactURI string, catalog *gemara.ControlCatalog) ([]byte, error) {
-	return ToSARIF(*c.log, artifactURI, catalog)
+func (c *EvaluationLogConverter) ToSARIF(opts ...EvalOption) ([]byte, error) {
+	return ToSARIF(c.log, opts...)
+}
+
+// ToOSCALAssessmentResults converts the EvaluationLog to an OSCAL Assessment Results document.
+func (c *EvaluationLogConverter) ToOSCALAssessmentResults(opts ...EvalOption) (oscal.AssessmentResults, error) {
+	return EvaluationLogToOSCALAssessmentResults(c.log, opts...)
 }
 
 // ControlCatalogConverter defines a converter for converting ControlCatalog.
 type ControlCatalogConverter struct {
-	catalog *gemara.ControlCatalog
+	catalog gemara.ControlCatalog
 }
 
 // ControlCatalog creates a new ControlCatalogConverter struct.
-func ControlCatalog(catalog *gemara.ControlCatalog) *ControlCatalogConverter {
+func ControlCatalog(catalog gemara.ControlCatalog) *ControlCatalogConverter {
 	return &ControlCatalogConverter{catalog: catalog}
 }
 
@@ -44,11 +51,11 @@ func (c *ControlCatalogConverter) ToMarkdown(ctx context.Context, opts ...Markdo
 
 // GuidanceCatalogConverter defines a converter for converting GuidanceCatalog.
 type GuidanceCatalogConverter struct {
-	guidance *gemara.GuidanceCatalog
+	guidance gemara.GuidanceCatalog
 }
 
 // GuidanceCatalog creates a new GuidanceCatalogConverter struct.
-func GuidanceCatalog(guidance *gemara.GuidanceCatalog) *GuidanceCatalogConverter {
+func GuidanceCatalog(guidance gemara.GuidanceCatalog) *GuidanceCatalogConverter {
 	return &GuidanceCatalogConverter{guidance: guidance}
 }
 

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/doc.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/doc.go
@@ -10,11 +10,11 @@
 //
 // Examples:
 //
-//	sarifBytes, err := gemaraconv.ToSARIF(&log, "file.md", catalog)
+//	sarifBytes, err := gemaraconv.ToSARIF(log, gemaraconv.WithArtifactURI("file.md"), gemaraconv.WithCatalog(catalog))
 //	oscalCatalog, err := gemaraconv.CatalogToOSCAL(catalog, gemaraconv.WithVersion("1.0"))
 //	md, err := gemaraconv.CatalogToMarkdown(ctx, catalog, gemaraconv.WithTOC(true), gemaraconv.WithLexiconAutolink(true))
 //	// Or pass list-shaped entries: WithInlineLexicon([]gemaraconv.InlineLexiconTerm{...})
-//	converter := gemaraconv.EvaluationLog(&log)
-//	sarifBytes, err := converter.ToSARIF("file.md", catalog)
+//	converter := gemaraconv.EvaluationLog(log)
+//	sarifBytes, err := converter.ToSARIF(gemaraconv.WithArtifactURI("file.md"), gemaraconv.WithCatalog(catalog))
 //	md, err := gemaraconv.ControlCatalog(catalog).ToMarkdown(ctx)
 package gemaraconv

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/guidance.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/guidance.go
@@ -14,7 +14,7 @@ import (
 // GuidanceToOSCAL converts a Gemara GuidanceCatalog to both an OSCAL Catalog and Profile.
 // The catalog includes only the locally defined guidelines (categories), not imported ones.
 // The profile includes imports for both external guidelines and the local catalog.
-func GuidanceToOSCAL(g *gemara.GuidanceCatalog, guidanceDocHref string, opts ...GenerateOption) (oscal.Catalog, oscal.Profile, error) {
+func GuidanceToOSCAL(g gemara.GuidanceCatalog, guidanceDocHref string, opts ...GenerateOption) (oscal.Catalog, oscal.Profile, error) {
 	// The guidanceDocHref parameter specifies the location where the OSCAL Catalog
 	// will be saved, used to create the import reference in the Profile. This must
 	// be a relative or absolute URI that accurately reflects where the catalog file
@@ -116,7 +116,7 @@ func GuidanceToOSCAL(g *gemara.GuidanceCatalog, guidanceDocHref string, opts ...
 	return catalog, profile, nil
 }
 
-func createControlGroup(g *gemara.GuidanceCatalog, group gemara.Group, guidelines []gemara.Guideline, resourcesMap map[string]string) oscal.Group {
+func createControlGroup(g gemara.GuidanceCatalog, group gemara.Group, guidelines []gemara.Guideline, resourcesMap map[string]string) oscal.Group {
 	oscalGroup := oscal.Group{
 		Class: "family",
 		ID:    group.Id,
@@ -291,7 +291,7 @@ func guidelineToParts(guideline gemara.Guideline, controlId string, guidelineId 
 	return parts
 }
 
-func guidelineToControl(g *gemara.GuidanceCatalog, guideline gemara.Guideline, resourcesMap map[string]string) (oscal.Control, string) {
+func guidelineToControl(g gemara.GuidanceCatalog, guideline gemara.Guideline, resourcesMap map[string]string) (oscal.Control, string) {
 	controlId := oscalUtils.NormalizeControl(guideline.Id, false)
 
 	control := oscal.Control{

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/markdown/lexicon_load.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/markdown/lexicon_load.go
@@ -10,9 +10,9 @@ import (
 	"github.com/gemaraproj/go-gemara/internal/codec"
 )
 
-// resolveLexiconURL returns the https:// or file:// URI for the lexicon artifact.
+// resolveLexiconURL returns the source string (URL or local path) for the lexicon artifact.
 // Precedence: metadata.mapping-references entry whose id matches metadata.lexicon.reference-id;
-// else metadata.lexicon.remarks if it is a fetchable URL.
+// else metadata.lexicon.remarks if it is a fetchable URL (must use http://, https://, or file://).
 func resolveLexiconURL(meta gemara.Metadata) (string, error) {
 	if meta.Lexicon == nil {
 		return "", fmt.Errorf("lexicon mapping is nil")
@@ -37,8 +37,8 @@ func resolveLexiconURL(meta gemara.Metadata) (string, error) {
 	return "", fmt.Errorf("no mapping-references entry with id %q for metadata.lexicon", refID)
 }
 
-// loadLexiconFromURI fetches a Lexicon from a file:// or http(s):// URI
-// and returns normalized entries.
+// loadLexiconFromURI fetches a Lexicon from an http(s):// URL, a file:// URI,
+// or a local file path, and returns normalized entries.
 func loadLexiconFromURI(ctx context.Context, uri string) ([]lexiconEntry, error) {
 	doc, err := gemara.Load[gemara.Lexicon](ctx, &fetcher.URI{}, uri)
 	if err != nil {

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/markdown/render.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/markdown/render.go
@@ -17,11 +17,7 @@ var templatesFS embed.FS
 
 // CatalogToMarkdown renders a ControlCatalog as Markdown using embedded templates.
 // Only controls whose state is LifecycleActive are included (TOC, body, and summary counts).
-func CatalogToMarkdown(ctx context.Context, catalog *gemara.ControlCatalog, cfg Config) ([]byte, error) {
-	if catalog == nil {
-		return nil, fmt.Errorf("catalog is nil")
-	}
-
+func CatalogToMarkdown(ctx context.Context, catalog gemara.ControlCatalog, cfg Config) ([]byte, error) {
 	lineEnding := cfg.LineEnding
 	if lineEnding == "" {
 		lineEnding = "\n"

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/markdown/view.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/markdown/view.go
@@ -105,11 +105,7 @@ func buildLexiconGlossaryView(entries []lexiconEntry) []markdownLexiconGlossaryE
 	return out
 }
 
-func buildMarkdownCatalogView(catalog *gemara.ControlCatalog, cfg Config, lexGlossary []markdownLexiconGlossaryEntry) markdownCatalogView {
-	if catalog == nil {
-		return markdownCatalogView{LineEnding: cfg.LineEnding, LexiconGlossary: lexGlossary}
-	}
-
+func buildMarkdownCatalogView(catalog gemara.ControlCatalog, cfg Config, lexGlossary []markdownLexiconGlossaryEntry) markdownCatalogView {
 	known := make(map[string]struct{}, len(catalog.Groups))
 	for _, g := range catalog.Groups {
 		known[g.Id] = struct{}{}
@@ -210,7 +206,7 @@ func buildMarkdownCatalogView(catalog *gemara.ControlCatalog, cfg Config, lexGlo
 
 // buildImportViews resolves each Import's ReferenceId against Metadata.MappingReferences
 // to populate the title and URL for the rendered imports section.
-func buildImportViews(catalog *gemara.ControlCatalog) []markdownImportView {
+func buildImportViews(catalog gemara.ControlCatalog) []markdownImportView {
 	if len(catalog.Imports) == 0 {
 		return nil
 	}
@@ -254,7 +250,7 @@ func arIncludedInApplicabilityMatrix(ar gemara.AssessmentRequirement) bool {
 // applicabilityColumnIDs returns ordered applicability ids for matrix columns:
 // metadata applicability-groups order if present, else sorted union of applicability
 // on non-retired assessment requirements under active controls.
-func applicabilityColumnIDs(catalog *gemara.ControlCatalog) []string {
+func applicabilityColumnIDs(catalog gemara.ControlCatalog) []string {
 	if len(catalog.Metadata.ApplicabilityGroups) > 0 {
 		out := make([]string, 0, len(catalog.Metadata.ApplicabilityGroups))
 		for _, g := range catalog.Metadata.ApplicabilityGroups {
@@ -284,8 +280,8 @@ func applicabilityColumnIDs(catalog *gemara.ControlCatalog) []string {
 	return out
 }
 
-func buildApplicabilityMatrix(catalog *gemara.ControlCatalog, groups []markdownGroupView, enabled bool) (cols []markdownApplicabilityColumn, rows []markdownApplicabilityMatrixRow, show bool) {
-	if !enabled || catalog == nil {
+func buildApplicabilityMatrix(catalog gemara.ControlCatalog, groups []markdownGroupView, enabled bool) (cols []markdownApplicabilityColumn, rows []markdownApplicabilityMatrixRow, show bool) {
+	if !enabled {
 		return nil, nil, false
 	}
 	colIDs := applicabilityColumnIDs(catalog)

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/metadata.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/metadata.go
@@ -61,7 +61,7 @@ func createMetadata(title string, version string, published *time.Time, canonica
 }
 
 // createMetadataFromGuidance creates OSCAL metadata from a GuidanceCatalog
-func createMetadataFromGuidance(guidance *gemara.GuidanceCatalog, opts generateOpts) (oscal.Metadata, error) {
+func createMetadataFromGuidance(guidance gemara.GuidanceCatalog, opts generateOpts) (oscal.Metadata, error) {
 	canonicalHref := ""
 	if opts.canonicalHref != "" {
 		canonicalHref = fmt.Sprintf(opts.canonicalHref, opts.version)
@@ -80,7 +80,7 @@ func createMetadataFromGuidance(guidance *gemara.GuidanceCatalog, opts generateO
 }
 
 // createMetadataFromCatalog creates OSCAL metadata from a ControlCatalog
-func createMetadataFromCatalog(catalog *gemara.ControlCatalog, opts generateOpts) (oscal.Metadata, error) {
+func createMetadataFromCatalog(catalog gemara.ControlCatalog, opts generateOpts) (oscal.Metadata, error) {
 	// Handle canonical HREF - prefer controlHREF for Catalog, fallback to canonicalHref
 	var canonicalHref string
 	if opts.controlHREF != "" {

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/options.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/options.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package gemaraconv
 
 import "github.com/gemaraproj/go-gemara"
@@ -9,7 +11,7 @@ type generateOpts struct {
 	controlHREF   string
 }
 
-func (g *generateOpts) completeFromGuidance(doc *gemara.GuidanceCatalog) {
+func (g *generateOpts) completeFromGuidance(doc gemara.GuidanceCatalog) {
 	if g.version == "" {
 		g.version = doc.Metadata.Version
 	}
@@ -21,7 +23,7 @@ func (g *generateOpts) completeFromGuidance(doc *gemara.GuidanceCatalog) {
 	}
 }
 
-func (g *generateOpts) completeFromCatalog(catalog *gemara.ControlCatalog) {
+func (g *generateOpts) completeFromCatalog(catalog gemara.ControlCatalog) {
 	if g.version == "" {
 		g.version = catalog.Metadata.Version
 	}
@@ -135,5 +137,45 @@ func WithLexiconAutolink(enabled bool) MarkdownOption {
 func WithInlineLexicon(terms []InlineLexiconTerm) MarkdownOption {
 	return func(o *markdownOpts) {
 		o.inlineLexicon = terms
+	}
+}
+
+type evalOpts struct {
+	catalog      *gemara.ControlCatalog
+	importApHref string
+	artifactURI  string
+}
+
+func defaultEvalOpts() evalOpts {
+	return evalOpts{importApHref: "#"}
+}
+
+// EvalOption configures EvaluationLog conversions (SARIF, OSCAL Assessment Results).
+// Options irrelevant to a particular output format are ignored.
+type EvalOption func(*evalOpts)
+
+// WithImportApHref sets the URI referencing the governing assessment plan.
+// Used by OSCAL Assessment Results; defaults to "#" if unset.
+func WithImportApHref(href string) EvalOption {
+	return func(o *evalOpts) {
+		if href != "" {
+			o.importApHref = href
+		}
+	}
+}
+
+// WithCatalog provides a ControlCatalog to enrich output with control titles,
+// requirement text, and recommendations. Used by both SARIF and OSCAL Assessment Results.
+func WithCatalog(catalog *gemara.ControlCatalog) EvalOption {
+	return func(o *evalOpts) {
+		o.catalog = catalog
+	}
+}
+
+// WithArtifactURI sets the file path or URI for SARIF PhysicalLocation.
+// Used by SARIF conversion; defaults to a placeholder when empty.
+func WithArtifactURI(uri string) EvalOption {
+	return func(o *evalOpts) {
+		o.artifactURI = uri
 	}
 }

--- a/vendor/github.com/gemaraproj/go-gemara/gemaraconv/sarif.go
+++ b/vendor/github.com/gemaraproj/go-gemara/gemaraconv/sarif.go
@@ -13,18 +13,19 @@ var emptyArtifactURIMessage = "no file associated with this alert"
 // Each AssessmentLog is emitted as a SARIF result. The rule id is derived from
 // the control id and requirement id.
 //
-// Parameters:
-//   - evaluationLog: The evaluation log to convert
-//   - artifactURI: File path or URI for PhysicalLocation.artifactLocation.uri.
-//     If empty, PhysicalLocation will be nil (no resource URI available).
-//     For GitHub Code Scanning, typically use a file path like "README.md".
-//   - catalog: Optional catalog data to enrich SARIF output with requirement text
-//     and recommendations. If nil, only basic information is included.
+// Use WithArtifactURI to set PhysicalLocation (defaults to a placeholder).
+// Use WithCatalog to enrich rules with requirement text and recommendations.
 //
 // PhysicalLocation identifies the artifact (file/repository) where the result was found.
 // LogicalLocation identifies the logical component (assessment step) that produced the result.
 // Region is left nil as we don't have file-specific line/column data.
-func ToSARIF(evaluationLog gemara.EvaluationLog, artifactURI string, catalog *gemara.ControlCatalog) ([]byte, error) {
+func ToSARIF(evaluationLog gemara.EvaluationLog, opts ...EvalOption) ([]byte, error) {
+	options := defaultEvalOpts()
+	for _, opt := range opts {
+		opt(&options)
+	}
+	artifactURI := options.artifactURI
+	catalog := options.catalog
 	report := &SarifReport{
 		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/123e95847b13fbdd4cbe2120fa5e33355d4a042b/Schemata/sarif-schema-2.1.0.json",
 		Version: "2.1.0",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/erikgeiser/coninput
 # github.com/fatih/color v1.18.0
 ## explicit; go 1.17
 github.com/fatih/color
-# github.com/gemaraproj/go-gemara v0.4.0
+# github.com/gemaraproj/go-gemara v0.5.0
 ## explicit; go 1.25.0
 github.com/gemaraproj/go-gemara
 github.com/gemaraproj/go-gemara/bundle


### PR DESCRIPTION
## Summary

- Updates `complytime.yaml` to pull policies from `quay.io/complytime/policies-ampel-branch-protection:latest` instead of localhost
- Updates `docs/QUICK_START.md` examples to use new per-bundle OCI repository naming
- Adds cross-reference ADR (`docs/adr/0001-one-quay-repo-per-bundle.md`) pointing to the canonical decision in `complytime-policies`

## Context

Follows from which refactors OCI publishing to use one Quay repository per policy bundle with a `policies-` prefix.

**Before:** `quay.io/complytime/complytime-policies@ampel-branch-protection`
**After:** `quay.io/complytime/policies-ampel-branch-protection:latest`

## Test plan

- [ ] `complyctl scan` resolves the new Quay URL correctly (once policies are published)
- [ ] Quick Start instructions are accurate for new users